### PR TITLE
Feature request: action to copy username (and possibly other, arbitrary, fields)

### DIFF
--- a/ivy-pass.el
+++ b/ivy-pass.el
@@ -48,7 +48,10 @@
     "rename")
    ("g"
     ivy-pass--generate-action
-    "generate")))
+    "generate")
+   ("u"
+    ivy-pass--username-action
+    "username")))
 
 (defun ivy-pass--add-action (key)
   "Ask for a new key based on KEY, then edit it."
@@ -80,6 +83,10 @@ Default PASSWORD-LENGTH is ‘password-store-password-length’."
 (defun ivy-pass--password-action (key)
   "Add password for KEY to kill ring."
   (password-store-copy key))
+
+(defun ivy-pass--username-action (key)
+  "Add username for KEY to kill ring."
+  (password-store-copy-field key "username"))
 
 ;;;###autoload
 (defun ivy-pass ()

--- a/ivy-pass.el
+++ b/ivy-pass.el
@@ -51,7 +51,10 @@
     "generate")
    ("u"
     ivy-pass--username-action
-    "username")))
+    "username")
+   ("c"
+    ivy-pass--choose-field-action
+    "choose field")))
 
 (defun ivy-pass--add-action (key)
   "Ask for a new key based on KEY, then edit it."
@@ -87,6 +90,10 @@ Default PASSWORD-LENGTH is ‘password-store-password-length’."
 (defun ivy-pass--username-action (key)
   "Add username for KEY to kill ring."
   (password-store-copy-field key "username"))
+
+(defun ivy-pass--choose-field-action (key)
+  "Choose a field from KEY's entry and copy its value to kill ring."
+  (password-store-copy-field key (password-store-read-field key)))
 
 ;;;###autoload
 (defun ivy-pass ()


### PR DESCRIPTION
I used to use [pass.el](https://github.com/NicolasPetton/pass), but I've recently switched to ivy-pass. The only feature I miss is the ability to copy the `username` field from a pass entry. [It doesn't seem too difficult to implement](https://github.com/NicolasPetton/pass/blob/master/pass.el#L312).

Thinking about it, and looking at the code, it would be easy and possibly useful to implement copying arbitrary fields from an entry too. I'm thinking that an action like `copy-arbitrary-field` would just invoke a new ivy completion over the fields of the entry, excluding the password, which could then be copied as usual.