### PR TITLE
Add `browse url' Action

### DIFF
--- a/ivy-pass.el
+++ b/ivy-pass.el
@@ -46,6 +46,9 @@
    ("r"
     ivy-pass--rename-action
     "rename")
+   ("b"
+    ivy-pass--browse-url-action
+    "browse url")
    ("g"
     ivy-pass--generate-action
     "generate")))
@@ -76,6 +79,10 @@ Default PASSWORD-LENGTH is ‘password-store-password-length’."
   "Rename entry for KEY."
   (let ((new-name (read-string (format "Rename `%s' to: " key) key)))
     (password-store-rename key new-name)))
+
+(defun ivy-pass--browse-url-action (key)
+  "Browse url field of KEY."
+  (password-store-url key))
 
 (defun ivy-pass--password-action (key)
   "Add password for KEY to kill ring."


### PR DESCRIPTION
Add action `browse url' on the key `b', to browse the `url' field in the entry.

I have found this to be quite useful in my own day to day use of pass. "url" is also one of the special fields recognised by `pass-store.el` as commonly enough used to warrant it's own function, so it seemed to me we might as well implement it here too.